### PR TITLE
Merge feature/asset-url-fix into master

### DIFF
--- a/src/Framework/ModuleAssets.php
+++ b/src/Framework/ModuleAssets.php
@@ -163,7 +163,10 @@ class ModuleAssets
             return $this->devBuildUrl . '/' . $assetPath->relativeTo($this->productionBuildPath);
         }
         $buildAssetPath = $this->buildAssetPath($assetPath);
-        return $buildAssetPath ? $buildAssetPath->url() : $relativePath;
+        if ($buildAssetPath) {
+            return $buildAssetPath->url();
+        }
+        return $assetPath->exists() ? $assetPath->url() : $relativePath;
     }
 
     private function scriptUrl(string $relative): string


### PR DESCRIPTION
@cyruscollier I ran into an issue locally where the trailing slash was not getting applied (idk if this is a server config thing or not) but the console was throwing errors from ModuleAssets::assetUrl() out of the box. This was the fix for it.

Quite possible we dont need this, but this was my way of flagging an issue I ran into.