### PR TITLE
Fix test assets loading in production

### DIFF
--- a/src/Framework/Bootstrap.php
+++ b/src/Framework/Bootstrap.php
@@ -19,7 +19,7 @@ class Bootstrap
             add_filter('timber/cache/mode', fn() => Loader::CACHE_NONE);
         }
 
-        if (defined('WP_TESTS_CONFIG_FILE_PATH') || getenv('WP_PHPUNIT__DIR')) {
+        if (defined('WP_TESTS_CONFIG_FILE_PATH')) {
             add_filter(
                 Hooks::name(ConfigRegistry::PATH_FILTER_HOOK),
                 fn($paths) => [...$paths, SITCHCO_CORE_TESTS_DIR],


### PR DESCRIPTION
## Problem

Test assets (e.g., `sitchco/test-block`) were being loaded in the browser, causing 404 errors:

```
GET /wp-content/mu-plugins/sitchco-core/tests/dist/assets/test-block-test-abcde.css => 404
GET /wp-content/mu-plugins/sitchco-core/tests/dist/assets/test-block-test1-abcde.js => 404
```

## Root Cause

The `wp-phpunit/wp-phpunit` package (a dependency of `cyruscollier/wp-test`) sets `WP_PHPUNIT__DIR` unconditionally via Composer autoloader on every request:

```php
// wp-phpunit/__loaded.php
putenv( sprintf( 'WP_PHPUNIT__DIR=%s', dirname( __FILE__ ) ) );
```

This caused the Bootstrap.php condition `getenv('WP_PHPUNIT__DIR')` to always be true, registering test paths even outside of PHPUnit runs.

## Fix

Remove the `getenv('WP_PHPUNIT__DIR')` check. The `WP_TESTS_CONFIG_FILE_PATH` constant (defined in `phpunit.xml`) is the correct check since it only exists during actual test runs.

## Test plan

- [x] Verified test block no longer registered in production
- [x] Verified no more 404 errors for test assets in browser
- [x] Verified PHPUnit tests still pass (165 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)