### PR TITLE
Editor UI lifecycle pipeline

### DIFF
--- a/modules/UIFramework/UIFramework.php
+++ b/modules/UIFramework/UIFramework.php
@@ -7,9 +7,13 @@ use Sitchco\Framework\ModuleAssets;
 
 class UIFramework extends Module
 {
-    const FEATURES = ['loadAssets'];
+    const FEATURES = ['loadAssets', 'loadEditorAssets'];
 
-    const HOOK_SUFFIX = 'ui-framework';
+    const HANDLE = 'ui-framework';
+
+    const HOOKS_HANDLE = 'sitchco/hooks';
+    const EDITOR_HANDLE = 'editor-ui-framework';
+    const EDITOR_FLUSH_HANDLE = 'ui-editor-flush';
 
     protected const NO_JS_SCRIPT = "
             document.documentElement.classList.remove('no-js');
@@ -19,11 +23,21 @@ class UIFramework extends Module
             });
         ";
 
+    protected const EDITOR_FLUSH_SCRIPT = "
+            console.log('editor flush');
+            if(window.sitchco?.editorFlush) {
+                window.sitchco.editorFlush();
+            }
+        ";
+
     public function init(): void
     {
         $this->registerAssets(function (ModuleAssets $assets) {
-            $assets->registerScript(static::HOOK_SUFFIX, 'main.mjs', ['wp-hooks']);
-            $assets->registerStyle(static::HOOK_SUFFIX, 'main.css');
+            $assets->registerScript(static::HOOKS_HANDLE, 'hooks.js', ['wp-hooks']);
+            $assets->registerScript(static::HANDLE, 'main.js', [static::HOOKS_HANDLE]);
+            $assets->registerScript(static::EDITOR_HANDLE, 'editor-ui-main.js', [static::HOOKS_HANDLE]);
+            $assets->registerScript(static::EDITOR_FLUSH_HANDLE, false);
+            $assets->registerStyle(static::HANDLE, 'main.css');
             add_filter(
                 'language_attributes',
                 fn($attributes) => !str_contains($attributes, 'class=')
@@ -33,12 +47,27 @@ class UIFramework extends Module
         });
     }
 
+    public function loadEditorAssets(): void
+    {
+        $this->enqueueEditorUIAssets(function (ModuleAssets $assets) {
+            $assets->enqueueScript(static::EDITOR_HANDLE);
+        }, 1);
+
+        // Enqueue flush as the very last editor script.
+        // No dependencies needed — WordPress outputs queue items in enqueue order,
+        // so PHP_INT_MAX ensures this inline script appears after all other editor scripts.
+        $this->enqueueEditorUIAssets(function (ModuleAssets $assets) {
+            $assets->enqueueScript(static::EDITOR_FLUSH_HANDLE);
+            $assets->inlineScript(static::EDITOR_FLUSH_HANDLE, static::EDITOR_FLUSH_SCRIPT);
+        }, PHP_INT_MAX);
+    }
+
     public function loadAssets(): void
     {
         $this->enqueueFrontendAssets(function (ModuleAssets $assets) {
-            $assets->enqueueScript(static::HOOK_SUFFIX);
-            $assets->enqueueStyle(static::HOOK_SUFFIX);
-            $assets->inlineScript(static::HOOK_SUFFIX, static::NO_JS_SCRIPT, 'before');
+            $assets->enqueueScript(static::HANDLE);
+            $assets->enqueueStyle(static::HANDLE);
+            $assets->inlineScript(static::HANDLE, static::NO_JS_SCRIPT, 'before');
         });
     }
 }

--- a/modules/UIFramework/assets/scripts/editor-ui-main.js
+++ b/modules/UIFramework/assets/scripts/editor-ui-main.js
@@ -1,0 +1,26 @@
+const EDITOR_INIT = 'editorInit';
+const EDITOR_READY = 'editorReady';
+
+const editorInit = (cb, priority = 100) => sitchco.hooks.addAction(EDITOR_INIT, cb, priority);
+const editorReady = (cb, priority = 100) => sitchco.hooks.addAction(EDITOR_READY, cb, priority);
+
+let flushed = false;
+
+function editorFlush() {
+    if (flushed) {
+        return;
+    }
+
+    flushed = true;
+    sitchco.hooks.doAction(EDITOR_INIT);
+    sitchco.hooks.doAction(EDITOR_READY);
+}
+
+window.sitchco = Object.assign(window.sitchco || {}, {
+    editorInit,
+    editorReady,
+    editorFlush,
+});
+
+// Fallback if PHP flush doesn't fire
+document.addEventListener('DOMContentLoaded', editorFlush);

--- a/modules/UIFramework/assets/scripts/hooks.js
+++ b/modules/UIFramework/assets/scripts/hooks.js
@@ -1,4 +1,4 @@
-import { NAMESPACE } from './constants.mjs';
+const NAMESPACE = 'sitchco';
 
 const {
     addAction: _addAction,
@@ -34,47 +34,52 @@ function buildNamespace(subNamespace) {
 /**
  * Add a namespaced action.
  */
-export function addAction(hookName, callback, priority = 10, subNamespace = '') {
+function addAction(hookName, callback, priority = 10, subNamespace = '') {
     _addAction(hookName, buildNamespace(subNamespace), callback, priority);
 }
 
 /**
  * Add a namespaced filter.
  */
-export function addFilter(hookName, callback, priority = 10, subNamespace = '') {
+function addFilter(hookName, callback, priority = 10, subNamespace = '') {
     _addFilter(hookName, buildNamespace(subNamespace), callback, priority);
 }
 
 /**
  * Remove a namespaced action.
  */
-export function removeAction(hookName, callback, subNamespace) {
+function removeAction(hookName, callback, subNamespace) {
     _removeAction(hookName, buildNamespace(subNamespace), callback);
 }
 
 /**
  * Remove a namespaced filter.
  */
-export function removeFilter(hookName, callback, subNamespace) {
+function removeFilter(hookName, callback, subNamespace) {
     _removeFilter(hookName, buildNamespace(subNamespace), callback);
 }
 
 /**
  * Check if a namespaced action exists.
  */
-export function hasAction(hookName, subNamespace = '') {
+function hasAction(hookName, subNamespace = '') {
     return _hasAction(hookName, buildNamespace(subNamespace));
 }
 
 /**
  * Check if a namespaced filter exists.
  */
-export function hasFilter(hookName, subNamespace = '') {
+function hasFilter(hookName, subNamespace = '') {
     return _hasFilter(hookName, buildNamespace(subNamespace));
 }
 
-// Pass through exports for rest of API
-export {
+const hooks = {
+    addAction,
+    addFilter,
+    removeAction,
+    removeFilter,
+    hasAction,
+    hasFilter,
     removeAllActions,
     removeAllFilters,
     doAction,
@@ -89,3 +94,7 @@ export {
     filters,
     defaultHooks,
 };
+
+window.sitchco = Object.assign(window.sitchco || {}, {
+    hooks,
+});

--- a/modules/UIFramework/assets/scripts/lib/accessibility.mjs
+++ b/modules/UIFramework/assets/scripts/lib/accessibility.mjs
@@ -1,5 +1,3 @@
-import { addAction } from './hooks.mjs';
-
 const COMPONENT = 'accessibility';
 
 const FOCUSABLE_SELECTOR = [
@@ -19,7 +17,7 @@ function registerFocusStateDetection() {
     let isAccessibleMode = false;
     document.body.classList.add('accessibility-off');
 
-    addAction(
+    sitchco.hooks.addAction(
         'key.tab',
         () => {
             if (!isAccessibleMode) {
@@ -176,7 +174,7 @@ function registerButtons() {
 function registerFocusTrapActions() {
     let currentTrap = null;
 
-    addAction(
+    sitchco.hooks.addAction(
         'focusTrapInit',
         (el) => {
             if (currentTrap) {
@@ -189,7 +187,7 @@ function registerFocusTrapActions() {
         COMPONENT
     );
 
-    addAction(
+    sitchco.hooks.addAction(
         'focusTrapActivate',
         () => {
             if (currentTrap) {
@@ -200,7 +198,7 @@ function registerFocusTrapActions() {
         COMPONENT
     );
 
-    addAction(
+    sitchco.hooks.addAction(
         'focusTrapDeactivate',
         () => {
             if (currentTrap) {

--- a/modules/UIFramework/assets/scripts/lib/css-vars.mjs
+++ b/modules/UIFramework/assets/scripts/lib/css-vars.mjs
@@ -1,4 +1,3 @@
-import { addAction, addFilter, applyFilters } from './hooks.mjs';
 import { LAYOUT, LAYOUTEND, READY, SCROLL } from './constants.mjs';
 import { scrollPosition } from './viewport.mjs';
 
@@ -24,26 +23,26 @@ export function registerCssVarsActions() {
     const layoutStyles = new DynamicStylesheet('dynamic-styles');
     const scrollStyles = new DynamicStylesheet('scroll-styles');
     let currentScrollPosition = scrollPosition().top;
-    addAction(
+    sitchco.hooks.addAction(
         READY,
         function () {
-            const useScroll = applyFilters('css-vars.use-scroll', false);
-            layoutStyles.styles = applyFilters('css-vars.register', layoutStyles.styles);
+            const useScroll = sitchco.hooks.applyFilters('css-vars.use-scroll', false);
+            layoutStyles.styles = sitchco.hooks.applyFilters('css-vars.register', layoutStyles.styles);
             layoutStyles.update();
 
             if (useScroll) {
-                scrollStyles.styles = applyFilters('css-vars.register-scroll', scrollStyles.styles);
+                scrollStyles.styles = sitchco.hooks.applyFilters('css-vars.register-scroll', scrollStyles.styles);
                 scrollStyles.update();
-                addAction(SCROLL, () => scrollStyles.update(), 10);
+                sitchco.hooks.addAction(SCROLL, () => scrollStyles.update(), 10);
             }
         },
         100
     );
 
-    addAction(LAYOUT, () => layoutStyles.update(), 10);
-    addAction(LAYOUTEND, () => layoutStyles.update(), 10);
-    addAction('css-vars.refresh', () => layoutStyles.update(), 10);
-    addFilter('css-vars.register-scroll', function (styles) {
+    sitchco.hooks.addAction(LAYOUT, () => layoutStyles.update(), 10);
+    sitchco.hooks.addAction(LAYOUTEND, () => layoutStyles.update(), 10);
+    sitchco.hooks.addAction('css-vars.refresh', () => layoutStyles.update(), 10);
+    sitchco.hooks.addFilter('css-vars.register-scroll', function (styles) {
         styles['scroll-direction'] = function () {
             const newPosition = scrollPosition().top;
             const direction = newPosition >= currentScrollPosition ? 1 : -1;

--- a/modules/UIFramework/assets/scripts/lib/event-actions.mjs
+++ b/modules/UIFramework/assets/scripts/lib/event-actions.mjs
@@ -1,4 +1,3 @@
-import { applyFilters, doAction } from './hooks.mjs';
 import * as viewport from './viewport.mjs';
 import { LAYOUT, LAYOUTEND, SCROLL, SCROLLSTART, SCROLLEND, USER_FIRST_INTERACTION, isiOS } from './constants.mjs';
 import { debounce, throttle } from './util.mjs';
@@ -13,9 +12,9 @@ export function updateLayout() {
 }
 
 export function registerLayoutActions() {
-    const debounceDelay = applyFilters('debounceDelay', 300) || 300;
-    const throttleLayout = applyFilters('layoutThrottle', 300) || 300;
-    const throttleScroll = applyFilters('scrollThrottle', 100) || 100;
+    const debounceDelay = sitchco.hooks.applyFilters('debounceDelay', 300) || 300;
+    const throttleLayout = sitchco.hooks.applyFilters('layoutThrottle', 300) || 300;
+    const throttleScroll = sitchco.hooks.applyFilters('scrollThrottle', 100) || 100;
     let docWidth = viewport.width();
     let isScrolling = false;
     let currentWidth = 0;
@@ -33,7 +32,7 @@ export function registerLayoutActions() {
     broadcastLayoutUpdate = throttle(
         () => {
             requestAnimationFrame(() => {
-                doAction(LAYOUT, widthHasChanged());
+                sitchco.hooks.doAction(LAYOUT, widthHasChanged());
             });
         },
         throttleLayout,
@@ -45,14 +44,14 @@ export function registerLayoutActions() {
 
     broadcastLayoutEnd = debounce(() => {
         requestAnimationFrame(() => {
-            doAction(LAYOUTEND);
+            sitchco.hooks.doAction(LAYOUTEND);
         });
     }, debounceDelay);
 
     const broadcastScrollEnd = debounce((event, position) => {
         isScrolling = false;
         requestAnimationFrame(() => {
-            doAction(SCROLLEND, event, position);
+            sitchco.hooks.doAction(SCROLLEND, event, position);
         });
     }, debounceDelay);
     const onScroll = throttle(
@@ -61,12 +60,12 @@ export function registerLayoutActions() {
             if (!isScrolling) {
                 isScrolling = true;
                 requestAnimationFrame(() => {
-                    doAction(SCROLLSTART, event, position);
+                    sitchco.hooks.doAction(SCROLLSTART, event, position);
                 });
             }
 
             requestAnimationFrame(() => {
-                doAction(SCROLL, event, position);
+                sitchco.hooks.doAction(SCROLL, event, position);
             });
 
             broadcastScrollEnd(event, position);
@@ -83,7 +82,7 @@ export function registerLayoutActions() {
         window.removeEventListener('touchend', onUserFirstInteraction);
         window.removeEventListener('wheel', onUserFirstInteraction);
         requestAnimationFrame(() => {
-            doAction(USER_FIRST_INTERACTION);
+            sitchco.hooks.doAction(USER_FIRST_INTERACTION);
         });
     };
 
@@ -115,7 +114,7 @@ export function registerLayoutActions() {
             27: 'esc',
         };
         if (codes.hasOwnProperty(code)) {
-            doAction('key.' + codes[code], e);
+            sitchco.hooks.doAction('key.' + codes[code], e);
         }
     });
 

--- a/modules/UIFramework/assets/scripts/lib/exit-intent.mjs
+++ b/modules/UIFramework/assets/scripts/lib/exit-intent.mjs
@@ -1,4 +1,3 @@
-import { doAction, applyFilters } from './hooks.mjs';
 import { debounce } from './util.mjs';
 
 let disabled = false;
@@ -6,11 +5,11 @@ let disabled = false;
 function detectExitIntent() {
     const triggerCustomEvent = debounce(
         () => {
-            if (!applyFilters('enableExitIntent', true) || disabled) {
+            if (!sitchco.hooks.applyFilters('enableExitIntent', true) || disabled) {
                 return;
             }
 
-            doAction('exitIntent');
+            sitchco.hooks.doAction('exitIntent');
             disabled = true;
         },
         500,
@@ -35,7 +34,7 @@ function detectExitIntent() {
 }
 
 export function registerExitIntentActions() {
-    if (applyFilters('enableExitIntent', false)) {
+    if (sitchco.hooks.applyFilters('enableExitIntent', false)) {
         detectExitIntent();
     }
 }

--- a/modules/UIFramework/assets/scripts/lib/hash-state.mjs
+++ b/modules/UIFramework/assets/scripts/lib/hash-state.mjs
@@ -1,5 +1,4 @@
 import { READY, SET_HASH_STATE, HASH_STATE_CHANGE } from './constants.mjs';
-import { addAction, doAction } from './hooks.mjs';
 
 function getPath() {
     return decodeURIComponent(location.hash.slice(1)).replace(/^\/+/, '');
@@ -39,7 +38,7 @@ let currentState = new HashState();
 export const hashState = {
     emit() {
         if (currentState.isset() && currentState.hasChanged()) {
-            doAction(HASH_STATE_CHANGE, currentState);
+            sitchco.hooks.doAction(HASH_STATE_CHANGE, currentState);
         }
     },
     isset() {
@@ -63,7 +62,7 @@ export const hashState = {
 };
 
 export function registerHashStateActions() {
-    addAction(
+    sitchco.hooks.addAction(
         READY,
         () => {
             hashState.emit();
@@ -74,7 +73,7 @@ export function registerHashStateActions() {
         99
     );
 
-    addAction(SET_HASH_STATE, (hash) => {
+    sitchco.hooks.addAction(SET_HASH_STATE, (hash) => {
         hashState.set(hash);
     });
 }

--- a/modules/UIFramework/assets/scripts/lib/header-height.mjs
+++ b/modules/UIFramework/assets/scripts/lib/header-height.mjs
@@ -1,12 +1,11 @@
-import { addAction, addFilter, applyFilters } from './hooks.mjs';
 import { debounce } from './util.mjs';
 import { HASH_STATE_CHANGE, isiOS } from './constants.mjs';
 
 export function registerHeaderHeightActions() {
     const header = document.querySelector('header');
     let headerHeight = header?.offsetHeight || 0;
-    addFilter('header-height', () => header?.offsetHeight || 0, 5);
-    addFilter(
+    sitchco.hooks.addFilter('header-height', () => header?.offsetHeight || 0, 5);
+    sitchco.hooks.addFilter(
         'header-offset',
         () => {
             if (window.scrollY === 0) {
@@ -17,9 +16,9 @@ export function registerHeaderHeightActions() {
         5
     );
 
-    addFilter('css-vars.register', (styles) => {
-        styles['header-height'] = () => `${applyFilters('header-height')}px`;
-        styles['header-offset'] = () => `${applyFilters('header-offset')}px`;
+    sitchco.hooks.addFilter('css-vars.register', (styles) => {
+        styles['header-height'] = () => `${sitchco.hooks.applyFilters('header-height')}px`;
+        styles['header-offset'] = () => `${sitchco.hooks.applyFilters('header-offset')}px`;
         return styles;
     });
 
@@ -68,13 +67,13 @@ export function registerHeaderHeightActions() {
 
             const targetOffset = actionTarget.getBoundingClientRect().top + window.scrollY;
             window.scrollTo({
-                top: targetOffset - applyFilters('header-height'),
+                top: targetOffset - sitchco.hooks.applyFilters('header-height'),
                 behavior: 'smooth',
             });
         },
         isiOS ? 300 : 0
     );
-    addAction(HASH_STATE_CHANGE, scrollTargetFallback);
+    sitchco.hooks.addAction(HASH_STATE_CHANGE, scrollTargetFallback);
     document.addEventListener('click', (event) => {
         const target = event.target.closest('a[href^="#"]');
         if (target) {

--- a/modules/UIFramework/assets/scripts/lib/scroll-watch.mjs
+++ b/modules/UIFramework/assets/scripts/lib/scroll-watch.mjs
@@ -1,4 +1,3 @@
-import { addAction } from './hooks.mjs';
 import { isInViewport, isVisible } from './viewport.mjs';
 import { READY, SCROLL, LAYOUT } from './constants.mjs';
 
@@ -66,7 +65,7 @@ window.addEventListener('load', () => {
 });
 
 export function registerScrollWatchActions() {
-    addAction(READY, checkElements);
-    addAction(SCROLL, checkElements);
-    addAction(LAYOUT, checkElements);
+    sitchco.hooks.addAction(READY, checkElements);
+    sitchco.hooks.addAction(SCROLL, checkElements);
+    sitchco.hooks.addAction(LAYOUT, checkElements);
 }

--- a/modules/UIFramework/assets/scripts/main.js
+++ b/modules/UIFramework/assets/scripts/main.js
@@ -1,7 +1,6 @@
 import * as constants from './lib/constants.mjs';
 import * as util from './lib/util.mjs';
 import * as viewport from './lib/viewport.mjs';
-import * as hooks from './lib/hooks.mjs';
 import { loadScript, registerScript } from './lib/script-registration.js';
 import { hashState, registerHashStateActions } from './lib/hash-state.mjs';
 import { registerLayoutActions, updateLayout } from './lib/event-actions.mjs';
@@ -11,13 +10,12 @@ import { registerCssVarsActions } from './lib/css-vars.mjs';
 import { registerExitIntentActions } from './lib/exit-intent.mjs';
 import { registerAccessibilityActions } from './lib/accessibility.mjs';
 
-const init = (cb, priority = 100) => hooks.addAction(constants.INIT, cb, priority);
-const register = (cb, priority = 100) => hooks.addAction(constants.REGISTER, cb, priority);
-const ready = (cb, priority = 100) => hooks.addAction(constants.READY, cb, priority);
+const init = (cb, priority = 100) => sitchco.hooks.addAction(constants.INIT, cb, priority);
+const register = (cb, priority = 100) => sitchco.hooks.addAction(constants.REGISTER, cb, priority);
+const ready = (cb, priority = 100) => sitchco.hooks.addAction(constants.READY, cb, priority);
 
 window.sitchco = Object.assign(window.sitchco || {}, {
     constants,
-    hooks,
     util,
     viewport,
     loadScript,
@@ -31,7 +29,7 @@ window.sitchco = Object.assign(window.sitchco || {}, {
 });
 
 // Init listeners
-hooks.addAction(
+sitchco.hooks.addAction(
     constants.READY,
     () => {
         hashState.emit();
@@ -42,7 +40,7 @@ hooks.addAction(
     99
 );
 
-hooks.addAction(constants.SET_HASH_STATE, (hash) => {
+sitchco.hooks.addAction(constants.SET_HASH_STATE, (hash) => {
     hashState.set(hash);
 });
 
@@ -58,11 +56,11 @@ window.addEventListener('DOMContentLoaded', () => {
     // Use this event if for external or non-explicit dependencies
     document.dispatchEvent(new CustomEvent('sitchco/core/init', window.sitchco));
     // Theme should register here to add any filters
-    hooks.doAction(constants.INIT);
+    sitchco.hooks.doAction(constants.INIT);
     // Components should register here so theme can filter
-    hooks.doAction(constants.REGISTER);
+    sitchco.hooks.doAction(constants.REGISTER);
     // Component post-registration actions can happen here
-    hooks.doAction(constants.READY);
+    sitchco.hooks.doAction(constants.READY);
 });
 
 window.addEventListener('load', () => {
@@ -72,7 +70,6 @@ window.addEventListener('load', () => {
 
 if (window.jQuery) {
     jQuery(document).bind('gform_confirmation_loaded', function (event, formId) {
-        hooks.doAction(constants.GFORM_CONFIRM, formId);
+        sitchco.hooks.doAction(constants.GFORM_CONFIRM, formId);
     });
 }
-// document.write('TEsting testing testing')

--- a/src/Framework/ModuleAssets.php
+++ b/src/Framework/ModuleAssets.php
@@ -75,12 +75,14 @@ class ModuleAssets
         return $buildPath->append($manifest[$assetKey]['file']);
     }
 
-    public function registerScript(string $handle, string $src, array $deps = []): void
+    public function registerScript(string $handle, string|false $src, array $deps = []): void
     {
         $handle = $this->namespacedHandle($handle);
-        $src = $this->scriptUrl($src);
-        if (!$src) {
-            return;
+        if (false !== $src) {
+            $src = $this->scriptUrl($src);
+            if (!$src) {
+                return;
+            }
         }
         wp_register_script($handle, $src, $deps);
     }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                    
   
  - **Add editor UI hook lifecycle pipeline to UIFramework** — a two-phase (`editorInit` → `editorReady`) synchronous boot sequence for block editor scripts, mirroring the     
  existing frontend three-phase lifecycle
  - **Extract hooks into a standalone shared entry** (`hooks.js`) — enables both frontend (`main.js`) and editor (`editor-ui-main.js`) scripts to share the same isolated
  `wp.hooks` instance without duplication
  - **Migrate all lib modules from imported hooks to global `sitchco.hooks.*` references** — eliminates direct ESM imports of hook functions across 7 lib files, making them
  work with the new shared hooks entry

  ### Editor Lifecycle Pipeline

  Scripts register callbacks into phases synchronously on load, then a late-priority flush executes them in order:

  1. `sitchco/editor-ui-framework` enqueues at priority **1** on `enqueue_block_editor_assets`
  2. Module scripts enqueue at default priority (10) — no more priority juggling between modules
  3. At `PHP_INT_MAX`, a flush script fires `sitchco.editorFlush()`, running `editorInit` then `editorReady` in sequence
  4. `DOMContentLoaded` fallback catches edge cases

  This replaces the previous approach of fragile PHP enqueue priorities (1, 1, 2, 5) and runtime `if (window.sitchco?.extendBlock)` guards.
