### PR TITLE
Decouple ModalData from Timber Post to support content-based modals

### DIFF
--- a/modules/UIModal/ModalData.php
+++ b/modules/UIModal/ModalData.php
@@ -6,28 +6,39 @@ use Timber\Post;
 
 readonly class ModalData
 {
-    /**
-     * @param Post $post
-     * @param ModalType $type
-     * @param bool $excerpt
-     */
-    public function __construct(private Post $post, public ModalType $type, private bool $excerpt = false) {}
+    private string $id;
+
+    public function __construct(string $id, private string $heading, private string $content, public ModalType $type)
+    {
+        $id = sanitize_title($id);
+        if (preg_match('/^\d/', $id)) {
+            $id = 'modal-' . $id;
+        }
+        $this->id = $id;
+    }
+
+    public static function fromPost(Post $post, ModalType $type, bool $excerpt = false): self
+    {
+        $heading = '';
+        if (!preg_match('/<h[1-6][\s>]/i', $post->post_content)) {
+            $heading = $post->title();
+        }
+        $content = $excerpt ? $post->excerpt() : $post->content();
+        return new self($post->slug, $heading, $content, $type);
+    }
 
     public function id(): string
     {
-        return $this->post->slug;
+        return $this->id;
     }
 
     public function heading(): string
     {
-        if (preg_match('/<h[1-6][\s>]/i', $this->post->post_content)) {
-            return '';
-        }
-        return $this->post->title();
+        return $this->heading;
     }
 
     public function content(): string
     {
-        return $this->excerpt ? $this->post->excerpt() : $this->post->content();
+        return $this->content;
     }
 }

--- a/modules/UIModal/README.md
+++ b/modules/UIModal/README.md
@@ -23,22 +23,23 @@ In the editor, the block renders an inline preview showing a truncated excerpt a
 
 ## Usage: PHP
 
-Inject `UIModal` from the container and call `loadModal()` with a Timber `Post`. The modal will be queued and output in `wp_footer`.
+Inject `UIModal` from the container and call `loadModal()` with a `ModalData` instance. The modal will be queued and output in `wp_footer`.
 
 ```php
+use Sitchco\Modules\UIModal\ModalData;
 use Sitchco\Modules\UIModal\UIModal;
 use Sitchco\Modules\UIModal\ModalType;
 
-$modal = $container->get(UIModal::class);
+$module = $container->get(UIModal::class);
 $post = \Timber\Timber::get_post($postId);
-$modal->loadModal($post, ModalType::CENTERED);
+$module->loadModal(ModalData::fromPost($post, ModalType::CENTERED));
 ```
 
 Assets are only enqueued when at least one modal has been loaded.
 
 ## Triggering a Modal
 
-Any element can open a modal by referencing its ID (the post slug):
+Any element can open a modal by referencing its ID. The ID is derived from the post slug via `sanitize_title()`. Slugs with leading digits receive a `modal-` prefix (e.g. `2024-update` becomes `modal-2024-update`).
 
 ```html
 <!-- Anchor link -->
@@ -184,7 +185,7 @@ Open/close animations use `@starting-style` and `transition-behavior: allow-disc
 UIModal/
 ├── UIModal.php           # Module class: registration, loading, rendering
 ├── ModalType.php         # Enum: BOX, CENTERED, VIDEO
-├── ModalData.php         # Readonly data model wrapping a Timber Post
+├── ModalData.php         # Readonly value object for modal ID, heading, content, and type
 ├── acf-json/             # ACF field group for the block
 ├── blocks/modal/         # Gutenberg block (block.json, block.php, block.twig, style.css)
 ├── templates/modal.twig  # Modal HTML template

--- a/modules/UIModal/UIModal.php
+++ b/modules/UIModal/UIModal.php
@@ -6,7 +6,6 @@ use Sitchco\Framework\Module;
 use Sitchco\Framework\ModuleAssets;
 use Sitchco\Modules\TimberModule;
 use Sitchco\Modules\UIFramework\UIFramework;
-use Timber\Post;
 use Sitchco\Utils\Str;
 use Sitchco\Utils\TimberUtil;
 
@@ -41,12 +40,16 @@ class UIModal extends Module
         });
     }
 
-    public function loadModal(Post $post, ModalType $type = ModalType::BOX): ModalData
+    public function loadModal(ModalData $modal): ?ModalData
     {
-        if (!isset($this->modalsLoaded[$post->slug])) {
-            $this->modalsLoaded[$post->slug] = new ModalData($post, $type);
+        $id = $modal->id();
+        if (!$id) {
+            return null;
         }
-        return $this->modalsLoaded[$post->slug];
+        if (!isset($this->modalsLoaded[$id])) {
+            $this->modalsLoaded[$id] = $modal;
+        }
+        return $this->modalsLoaded[$id];
     }
 
     public function renderModalContent(ModalData $modalData): string

--- a/modules/UIModal/blocks/modal/block.json
+++ b/modules/UIModal/blocks/modal/block.json
@@ -2,7 +2,7 @@
     "name": "sitchco/modal",
     "title": "Modal",
     "apiVersion": 3,
-    "description": "A Gutenberg block for displaying a modal, hidden on front end until triggered by an anchor matching its post slug.",
+    "description": "A Gutenberg block for displaying a modal, hidden on front end until triggered by an anchor or data-target matching its ID.",
     "category": "sitchco",
     "keywords": ["modal", "acf"],
     "icon": "external",

--- a/modules/UIModal/blocks/modal/block.php
+++ b/modules/UIModal/blocks/modal/block.php
@@ -28,8 +28,8 @@ if ($context['is_preview']) {
         $pre_content_filter = true;
         add_filter(UIModal::hookName('pre-content'), fn($_, ModalData $modal) => "ID: #{$modal->id()}", 10, 2);
     }
-    return $module->renderModalContent(new ModalData($post, $type, true));
+    return $module->renderModalContent(ModalData::fromPost($post, $type, true));
 }
 
-$module->loadModal($post, $type);
+$module->loadModal(ModalData::fromPost($post, $type));
 return '';

--- a/tests/Modules/UIModal/ModalDataTest.php
+++ b/tests/Modules/UIModal/ModalDataTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Sitchco\Tests\Modules\UIModal;
+
+use Sitchco\Modules\UIModal\ModalData;
+use Sitchco\Modules\UIModal\ModalType;
+use Sitchco\Tests\TestCase;
+use Timber\Timber;
+
+class ModalDataTest extends TestCase
+{
+    public function test_id_prefixes_digit_starting_ids()
+    {
+        $normal = new ModalData('about-us', '', '', ModalType::BOX);
+        $this->assertEquals('about-us', $normal->id());
+
+        $digitPrefixed = new ModalData('42-things', '', '', ModalType::BOX);
+        $this->assertEquals('modal-42-things', $digitPrefixed->id());
+
+        $allDigit = new ModalData('123', '', '', ModalType::BOX);
+        $this->assertEquals('modal-123', $allDigit->id());
+    }
+
+    public function test_fromPost_omits_heading_when_content_contains_heading_tag()
+    {
+        $post_id = $this->factory()->post->create([
+            'post_title' => 'Modal Title',
+            'post_name' => 'modal-title',
+            'post_content' => '<h2>Section Title</h2><p>Body text</p>',
+        ]);
+        $post = Timber::get_post($post_id);
+        $modal = ModalData::fromPost($post, ModalType::BOX);
+
+        $this->assertEmpty($modal->heading());
+    }
+
+    public function test_fromPost_uses_post_title_when_content_has_no_heading()
+    {
+        $post_id = $this->factory()->post->create([
+            'post_title' => 'Modal Title',
+            'post_name' => 'modal-title',
+            'post_content' => '<p>Just a paragraph of content.</p>',
+        ]);
+        $post = Timber::get_post($post_id);
+        $modal = ModalData::fromPost($post, ModalType::CENTERED);
+
+        $this->assertEquals('Modal Title', $modal->heading());
+    }
+
+    public function test_fromPost_uses_excerpt_when_flag_is_true()
+    {
+        $post_id = $this->factory()->post->create([
+            'post_title' => 'Modal Title',
+            'post_name' => 'modal-title',
+            'post_content' => '<p>This is the full content of the modal.</p>',
+            'post_excerpt' => 'Short summary',
+        ]);
+        $post = Timber::get_post($post_id);
+
+        $withContent = ModalData::fromPost($post, ModalType::BOX);
+        $withExcerpt = ModalData::fromPost($post, ModalType::BOX, excerpt: true);
+
+        $this->assertStringContainsString('full content of the modal', $withContent->content());
+        $this->assertStringContainsString('Short summary', $withExcerpt->content());
+    }
+}


### PR DESCRIPTION
## Summary

- Refactor `ModalData` into a standalone value object with a primitive constructor (`id`, `heading`, `content`, `ModalType`) and a `fromPost()` static factory that preserves existing post-based behavior
- Update `UIModal::loadModal()` to accept `ModalData` directly instead of a `Post`, with null return for empty/invalid IDs
- Sanitize modal IDs via `sanitize_title()` and prefix digit-leading slugs with `modal-` to ensure valid HTML element IDs
- Add `ModalDataTest` covering ID prefix logic, heading presence/absence, and excerpt flag

## Jira

[SP-466](https://situation.atlassian.net/browse/SP-466)

## Test plan

- [ ] Verify existing post-based modals still render and trigger correctly
- [ ] Verify modal IDs with digit-leading slugs get the `modal-` prefix
- [ ] Run `ModalDataTest` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)