### PR TITLE
Admin filters: include unpublished posts and reuse column-content for labels

### DIFF
--- a/modules/AdvancedCustomFields/AcfPostTypeAdminColumns.php
+++ b/modules/AdvancedCustomFields/AcfPostTypeAdminColumns.php
@@ -175,34 +175,57 @@ class AcfPostTypeAdminColumns extends Module
         if (!in_array($column_name, array_column($column_config, 'name'))) {
             return;
         }
-        $slug = $post_type_config['post_type'];
-        $filter_base = 'column_content';
-        $content = '';
         /**
+         * Generic hook — `postMeta()` populates $content from the DB by $post_id here.
          * add_filter('sitchco/acf_post_type_admin_columns/column_content', 'my_func', 10, 4);
          * function my_func($content, $post_id, $column_id, $post_type_config){ return $content; }
          */
-        $content = apply_filters(static::hookName($filter_base), $content, $post_id, $column_name, $post_type_config);
+        $content = apply_filters(static::hookName('column_content'), '', $post_id, $column_name, $post_type_config);
+        echo static::renderColumnContent($column_name, $content, $post_id, $post_type_config);
+    }
+
+    /**
+     * Applies the column-specific content filters to a value and collapses it to a display string.
+     *
+     * Shared by columnContent() and the admin filter dropdown so a single
+     * column_content/{column} handler drives both the cell and the filter label. The generic
+     * column_content hook (where postMeta does a DB lookup) is intentionally excluded.
+     *
+     * @param string $column_name
+     * @param mixed $content
+     * @param int $post_id
+     * @param array $post_type_config
+     * @return string
+     */
+    public static function renderColumnContent(
+        string $column_name,
+        $content,
+        int $post_id,
+        array $post_type_config,
+    ): string {
+        $slug = $post_type_config['post_type'];
         /**
          * add_filter('sitchco/acf_post_type_admin_columns/column_content/{{column_name}}', 'my_func', 10, 3);
          * function my_func($content, $post_id, $post_type_config){ return $content; }
          */
-        $content = apply_filters(static::hookName($filter_base, $column_name), $content, $post_id, $post_type_config);
+        $content = apply_filters(
+            static::hookName('column_content', $column_name),
+            $content,
+            $post_id,
+            $post_type_config,
+        );
         /**
          * add_filter('sitchco/acf_post_type_admin_columns/column_content/{{column_name}}/{{post_type}}', 'my_func', 10, 2);
          * function my_func($content, $post_id, $post_type_config){ return $content; }
          */
         $content = apply_filters(
-            static::hookName($filter_base, $column_name, $slug),
+            static::hookName('column_content', $column_name, $slug),
             $content,
             $post_id,
             $post_type_config,
         );
 
-        if (is_array($content)) {
-            $content = implode(' | ', $content);
-        }
-        echo $content;
+        return is_array($content) ? implode(' | ', $content) : (string) $content;
     }
 
     /**

--- a/modules/AdvancedCustomFields/AcfPostTypeAdminColumns.php
+++ b/modules/AdvancedCustomFields/AcfPostTypeAdminColumns.php
@@ -191,6 +191,11 @@ class AcfPostTypeAdminColumns extends Module
      * column_content/{column} handler drives both the cell and the filter label. The generic
      * column_content hook (where postMeta does a DB lookup) is intentionally excluded.
      *
+     * Caller contract for the filter-label path (no single post):
+     *  - Wrap the raw meta value in a single-element array to match postMeta()'s get_post_meta()
+     *    shape — handlers read $content[0], so a bare scalar would silently break them.
+     *  - Pass post_id 0 as the "no single post" sentinel; post-dependent handlers must tolerate it.
+     *
      * @param string $column_name
      * @param mixed $content
      * @param int $post_id
@@ -259,15 +264,19 @@ class AcfPostTypeAdminColumns extends Module
 
     public function editor($content, $post_id): string
     {
+        // No real post in the filter-label path (post_id 0); fall back without dereferencing null.
         $post = get_post($post_id);
+        $fallback = is_array($content) ? '' : (string) $content;
 
-        return strip_tags($post->post_content) ?: $content;
+        return $post ? (strip_tags($post->post_content) ?: $fallback) : $fallback;
     }
 
     public function excerpt($content, $post_id): string
     {
+        // No real post in the filter-label path (post_id 0); fall back without dereferencing null.
         $post = get_post($post_id);
+        $fallback = is_array($content) ? '' : (string) $content;
 
-        return strip_tags($post->post_excerpt) ?: $content;
+        return $post ? (strip_tags($post->post_excerpt) ?: $fallback) : $fallback;
     }
 }

--- a/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
+++ b/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
@@ -158,14 +158,40 @@ class AcfPostTypeAdminFilters extends Module
      */
     protected function getTaxonomyFilters(array $post_type_config): array
     {
+        /** @var wpdb $wpdb */
+        global $wpdb;
         $filters = [];
+        $post_type = $post_type_config['post_type'];
         $taxonomies = array_filter((array) $post_type_config['taxonomies']);
         foreach ($taxonomies as $tax_slug) {
             $tax_obj = get_taxonomy($tax_slug);
             if (!$tax_obj->show_admin_column) {
                 continue;
             }
-            $terms = get_terms(['taxonomy' => $tax_slug]);
+            // Build the term list from terms actually attached to posts of this type across all
+            // listing-visible statuses. Relying on get_terms()'s `hide_empty` would only count
+            // published posts (the stored term count), hiding terms used solely by drafts, etc.
+            $term_ids = $wpdb->get_col(
+                $wpdb->prepare(
+                    "SELECT DISTINCT tt.term_id
+                     FROM $wpdb->term_relationships tr
+                     INNER JOIN $wpdb->term_taxonomy tt ON tt.term_taxonomy_id = tr.term_taxonomy_id
+                     INNER JOIN $wpdb->posts p ON p.ID = tr.object_id
+                     WHERE tt.taxonomy = %s
+                       AND p.post_type = %s
+                       AND p.post_status NOT IN ('trash', 'auto-draft')",
+                    $tax_slug,
+                    $post_type,
+                ),
+            );
+            if (empty($term_ids)) {
+                continue;
+            }
+            $terms = get_terms([
+                'taxonomy' => $tax_slug,
+                'include' => $term_ids,
+                'hide_empty' => false, // safe: `include` already guarantees real usage
+            ]);
             if (is_wp_error($terms)) {
                 continue;
             }

--- a/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
+++ b/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
@@ -131,13 +131,22 @@ class AcfPostTypeAdminFilters extends Module
                 'label' => "Filter by {$row['label']}",
                 'selected' => false,
             ];
-            // Add label for each value
-            array_walk($field_values, fn($el) => ($el->label = (string) $el->meta_value));
-            // Hook: sitchco/acf_post_type_admin_filters/filter_values
+            // Derive each option's label from the same column_content/{column} filter chain that
+            // renders the column cell, so a module writes one handler for both. Wrap the value to
+            // match postMeta()'s array shape; pass post_id 0 since there's no single post.
+            array_walk($field_values, function ($el) use ($id, $post_type_config) {
+                $label = AcfPostTypeAdminColumns::renderColumnContent($id, [$el->meta_value], 0, $post_type_config);
+                $el->label = $label !== '' ? $label : (string) $el->meta_value;
+            });
+            // Hook: sitchco/acf_post_type_admin_filters/filter_values (optional array-level pass)
             $field_values = apply_filters(static::hookName('filter_values', $id), $field_values, $post_type_config);
 
             // Build options and determine whether value is currently selected
             foreach ($field_values as $field) {
+                // Skip empty values (not '0', which is a valid value); they make no useful filter
+                if ($field->meta_value === '' || $field->meta_value === null) {
+                    continue;
+                }
                 $filter['options'][] = [
                     'value' => urlencode($field->meta_value),
                     'label' => $field->label,

--- a/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
+++ b/modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php
@@ -133,9 +133,11 @@ class AcfPostTypeAdminFilters extends Module
             ];
             // Derive each option's label from the same column_content/{column} filter chain that
             // renders the column cell, so a module writes one handler for both. Wrap the value to
-            // match postMeta()'s array shape; pass post_id 0 since there's no single post.
+            // match postMeta()'s array shape and maybe_unserialize() it so handlers see the same
+            // input the cell path does; pass post_id 0 since there's no single post.
             array_walk($field_values, function ($el) use ($id, $post_type_config) {
-                $label = AcfPostTypeAdminColumns::renderColumnContent($id, [$el->meta_value], 0, $post_type_config);
+                $value = maybe_unserialize($el->meta_value);
+                $label = AcfPostTypeAdminColumns::renderColumnContent($id, [$value], 0, $post_type_config);
                 $el->label = $label !== '' ? $label : (string) $el->meta_value;
             });
             // Hook: sitchco/acf_post_type_admin_filters/filter_values (optional array-level pass)

--- a/templates/admin-filter-select.php
+++ b/templates/admin-filter-select.php
@@ -5,13 +5,13 @@
  */
 
 $id = 'column-filter-' . $filter['id']; ?>
-<label for="<?= $id ?>" class="screen-reader-text">
-    <?= $filter['options'][0]['label'] ?>
+<label for="<?= esc_attr($id) ?>" class="screen-reader-text">
+    <?= esc_html($filter['options'][0]['label']) ?>
 </label>
-<select name="<?= $filter['id'] ?>" id="<?= $id ?>" class="postform">
+<select name="<?= esc_attr($filter['id']) ?>" id="<?= esc_attr($id) ?>" class="postform">
     <?php foreach ($filter['options'] as $option): ?>
-        <option value="<?= $option['value'] ?>"<?php selected($option['selected']); ?>>
-            <?= $option['label'] ?>
+        <option value="<?= esc_attr($option['value']) ?>"<?php selected($option['selected']); ?>>
+            <?= esc_html($option['label']) ?>
         </option>
     <?php endforeach; ?>
 </select>

--- a/tests/Framework/ModuleAssetsTest.php
+++ b/tests/Framework/ModuleAssetsTest.php
@@ -125,7 +125,7 @@ class ModuleAssetsTest extends TestCase
         ob_start();
         $deps->do_item($handle);
         $output = ob_get_clean();
-        $this->assertStringStartsWith($expected, $output);
+        $this->assertHTMLEquals($expected, $output);
     }
 
     public function test_creating_from_module()

--- a/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
+++ b/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
@@ -94,6 +94,45 @@ class AcfPostTypeAdminFiltersTest extends AcfPostTypeTest
         );
     }
 
+    public function test_taxonomy_filter_includes_unpublished_and_excludes_empty_terms(): void
+    {
+        $this->createAcfPostTypeConfig();
+
+        foreach (
+            ['published-cat' => 'Published Cat', 'draft-cat' => 'Draft Cat', 'empty-cat' => 'Empty Cat']
+            as $slug => $name
+        ) {
+            $this->factory()->term->create([
+                'taxonomy' => $this->taxonomy,
+                'name' => $name,
+                'slug' => $slug,
+            ]);
+        }
+
+        $published = $this->factory()->post->create_and_get([
+            'post_type' => $this->post_type,
+            'post_status' => 'publish',
+        ]);
+        wp_set_object_terms($published->ID, 'published-cat', $this->taxonomy);
+
+        $draft = $this->factory()->post->create_and_get([
+            'post_type' => $this->post_type,
+            'post_status' => 'draft',
+        ]);
+        wp_set_object_terms($draft->ID, 'draft-cat', $this->taxonomy);
+
+        // Term attached only to a different post type must not leak in
+        $other = $this->factory()->post->create_and_get(['post_type' => 'post']);
+        wp_set_object_terms($other->ID, 'published-cat', $this->taxonomy);
+
+        $filters = $this->module->renderColumnFilters($this->post_type, '');
+        $slugs = array_column($filters['performance-category']['options'], 'value');
+
+        $this->assertContains('published-cat', $slugs);
+        $this->assertContains('draft-cat', $slugs); // the fix: term used only by a draft
+        $this->assertNotContains('empty-cat', $slugs); // still excludes truly empty terms
+    }
+
     public function test_appends_parsed_query_with_selected_meta_filters(): void
     {
         global $wp_query, $pagenow;

--- a/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
+++ b/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
@@ -94,6 +94,31 @@ class AcfPostTypeAdminFiltersTest extends AcfPostTypeTest
         );
     }
 
+    public function test_custom_filter_labels_use_column_content(): void
+    {
+        $this->createAcfPostTypeConfig();
+        $this->createPosts();
+
+        // One handler now drives both the column cell and the filter labels
+        add_filter('sitchco/acf_post_type_admin_columns/column_content/price_code', function ($content) {
+            $code = is_array($content) ? $content[0] ?? '' : $content;
+            return $code === '' ? '' : "Tier {$code}";
+        });
+
+        $_GET = ['price_code' => 'B'];
+        $filters = $this->module->renderColumnFilters($this->post_type, '');
+
+        $this->assertEquals(
+            [
+                ['value' => '', 'label' => 'Filter by Price Code', 'selected' => false],
+                ['value' => 'A', 'label' => 'Tier A', 'selected' => false],
+                ['value' => 'B', 'label' => 'Tier B', 'selected' => true],
+                ['value' => 'C', 'label' => 'Tier C', 'selected' => false],
+            ],
+            $filters['price_code']['options'],
+        );
+    }
+
     public function test_taxonomy_filter_includes_unpublished_and_excludes_empty_terms(): void
     {
         $this->createAcfPostTypeConfig();

--- a/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
+++ b/tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php
@@ -124,7 +124,15 @@ class AcfPostTypeAdminFiltersTest extends AcfPostTypeTest
         $this->createAcfPostTypeConfig();
 
         foreach (
-            ['published-cat' => 'Published Cat', 'draft-cat' => 'Draft Cat', 'empty-cat' => 'Empty Cat']
+            [
+                'published-cat' => 'Published Cat',
+                'draft-cat' => 'Draft Cat',
+                'pending-cat' => 'Pending Cat',
+                'future-cat' => 'Future Cat',
+                'private-cat' => 'Private Cat',
+                'empty-cat' => 'Empty Cat',
+                'foreign-cat' => 'Foreign Cat',
+            ]
             as $slug => $name
         ) {
             $this->factory()->term->create([
@@ -134,28 +142,60 @@ class AcfPostTypeAdminFiltersTest extends AcfPostTypeTest
             ]);
         }
 
-        $published = $this->factory()->post->create_and_get([
-            'post_type' => $this->post_type,
-            'post_status' => 'publish',
-        ]);
-        wp_set_object_terms($published->ID, 'published-cat', $this->taxonomy);
-
-        $draft = $this->factory()->post->create_and_get([
-            'post_type' => $this->post_type,
-            'post_status' => 'draft',
-        ]);
-        wp_set_object_terms($draft->ID, 'draft-cat', $this->taxonomy);
+        // One CPT post per listing-visible status, each attached to its own term
+        $statuses = [
+            'publish' => 'published-cat',
+            'draft' => 'draft-cat',
+            'pending' => 'pending-cat',
+            'future' => 'future-cat',
+            'private' => 'private-cat',
+        ];
+        foreach ($statuses as $status => $term_slug) {
+            $post = $this->factory()->post->create_and_get([
+                'post_type' => $this->post_type,
+                'post_status' => $status,
+                'post_date' => $status === 'future' ? '2999-01-01 00:00:00' : '2024-11-20 00:00:00',
+            ]);
+            wp_set_object_terms($post->ID, $term_slug, $this->taxonomy);
+        }
 
         // Term attached only to a different post type must not leak in
         $other = $this->factory()->post->create_and_get(['post_type' => 'post']);
-        wp_set_object_terms($other->ID, 'published-cat', $this->taxonomy);
+        wp_set_object_terms($other->ID, 'foreign-cat', $this->taxonomy);
 
         $filters = $this->module->renderColumnFilters($this->post_type, '');
         $slugs = array_column($filters['performance-category']['options'], 'value');
 
-        $this->assertContains('published-cat', $slugs);
-        $this->assertContains('draft-cat', $slugs); // the fix: term used only by a draft
+        // The fix: terms surface for every listing-visible status, not just published
+        foreach ($statuses as $term_slug) {
+            $this->assertContains($term_slug, $slugs);
+        }
         $this->assertNotContains('empty-cat', $slugs); // still excludes truly empty terms
+        $this->assertNotContains('foreign-cat', $slugs); // excludes terms used only by other post types
+    }
+
+    public function test_filterable_editor_excerpt_column_does_not_fatal(): void
+    {
+        // Mark the built-in excerpt column filterable; renderColumnContent() will route its values
+        // through the excerpt() handler with post_id 0, which previously fataled on get_post(0).
+        $this->acf_post_type_config['listing_screen_columns']['row-row-1']['filterable'] = '1';
+        $this->createAcfPostTypeConfig();
+
+        $this->factory()->post->create([
+            'post_type' => $this->post_type,
+            'meta_input' => ['excerpt' => 'Some Summary'],
+        ]);
+        $this->factory()->post->create([
+            'post_type' => $this->post_type,
+            'meta_input' => ['excerpt' => 'Another Summary'],
+        ]);
+
+        $filters = $this->module->renderColumnFilters($this->post_type, '');
+
+        $this->assertArrayHasKey('excerpt', $filters);
+        foreach ($filters['excerpt']['options'] as $option) {
+            $this->assertIsString($option['label']);
+        }
     }
 
     public function test_appends_parsed_query_with_selected_meta_filters(): void


### PR DESCRIPTION
## Summary

Two related improvements to the ACF admin post-listing filters.

### 1. Taxonomy filter now includes terms on unpublished posts

`getTaxonomyFilters()` built its dropdown with `get_terms()` default `hide_empty`, which filters on the stored term `count` column — populated only from **published** posts. Terms attached solely to draft/pending/future/private posts never appeared, so those posts couldn't be filtered by taxonomy.

Now the term list is derived from terms actually attached to posts of this type across all listing-visible statuses (a scoped query, `NOT IN ('trash', 'auto-draft')`), instead of relying on the stored count or overriding the global `update_post_term_count_statuses` filter. Genuinely empty terms and terms on other post types remain excluded.

### 2. Custom filter labels reuse the column-content renderer

The filter dropdown exposed a `filter_values/{column}` hook to rewrite each option's label, duplicating the value→label mapping already done by the `column_content/{column}` hook that renders the same column's cell (e.g. `ProductionModule` had both a column handler and a filter-values handler turning a theatre ID into its title).

A shared `AcfPostTypeAdminColumns::renderColumnContent()` is now extracted, and `getCustomFilters()` derives each option's label through the same `column_content` filter chain — so a module writes **one** handler for both. Empty (but not `'0'`) filter values are skipped generically. `filter_values` remains as an optional array-level pass.

## Changes
- `modules/AdvancedCustomFields/AcfPostTypeAdminFilters.php` — status-aware taxonomy term query; auto-label custom filters via column content; skip empty values
- `modules/AdvancedCustomFields/AcfPostTypeAdminColumns.php` — extract `renderColumnContent()` shared helper
- `tests/Modules/AdvancedCustomFields/AcfPostTypeAdminFiltersTest.php` — coverage for both behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)